### PR TITLE
Generate kendo.data.DataSource

### DIFF
--- a/build/generate.js
+++ b/build/generate.js
@@ -65,10 +65,7 @@ var mapping = {
     "kendo.version"
   ],
   "kendo.data.js" : [
-    // ???
-
-    // NOTE: kendo.data is usually not accessed directly, but rather as Kendo
-    // plugins
+    "kendo.data.DataSource"
   ],
   "kendo.data.odata.js" : [
     "kendo.data.schemas.odata",


### PR DESCRIPTION
I've been frequently accessing `kendo.data.DataSource` _after_ I include a module which uses it (which is basically everything). It would be nice to be able to access it directly.

This also has the added benefit of being able to separate out the core modules using Webpack's `CommonsChunkPlugin` and `require.include("kendo/kendo.data.DataSource")`.
