### PR TITLE
Resolve kendo-ui-core module using require.resolve

### DIFF
--- a/build/generate.js
+++ b/build/generate.js
@@ -289,9 +289,10 @@ console.log("done (" + count + " files written).");
 
 console.log("Copying styles...");
 
-var base_from = path.join(__dirname, "..", "node_modules", "kendo-ui-core",
-  "dist", "styles");
-var base_to = path.join(__dirname, "..", "styles");
+var base_from = path.join(
+  path.dirname(require.resolve("kendo-ui-core/package.json")),
+  "dist/styles");
+var base_to = path.join(__dirname, "../styles");
 
 wrench.copyDirSyncRecursive(base_from, base_to, {
   excludeHiddenUnix : false,
@@ -299,4 +300,3 @@ wrench.copyDirSyncRecursive(base_from, base_to, {
   preserveTimestamps : true,
   inflateSymlinks : false
 });
- 


### PR DESCRIPTION
NPM v3 uses a flattened `node_modules` folder structure. This fix will
work for both old and new versions of NPM by using `require.resolve`
instead of using a hardcoded `../node_modules/` path.

It also makes no difference to use `"/"` in paths as `path.join()` will convert
them to the OS-specific separator.
